### PR TITLE
remove goatcounter

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -115,12 +115,6 @@ const socialImageURL = new URL(
       crossorigin
     />
 
-    <script
-      data-goatcounter="https://jakegut.goatcounter.com/count"
-      async
-      src="//gc.zgo.at/count.js"
-    ></script>
-
     <script is:inline>
       const primaryColorScheme = "none"; // "light" | "dark" | "none"
 


### PR DESCRIPTION
I'm currently getting page hits from `hvadaparty-com.vercel.app`  which interferes with analytics from my personal site. I'd appreciate if the following lines were removed to prevent that